### PR TITLE
Fix workspace bind mount permissions and add Compose host overrides

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Docker Compose reads this file automatically when present as `.env`.
+# These values control the host side of docker-compose.full.yaml.
+
+# CloudCLI web UI host port
+HOLYCLAUDE_HOST_PORT=3001
+
+# Host bind-mount paths
+HOLYCLAUDE_HOST_CLAUDE_DIR=./data/claude
+HOLYCLAUDE_HOST_WORKSPACE_DIR=./workspace

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # HolyClaude persistent data (created at runtime)
 data/
-workspace/
+workspace/*
+!workspace/.gitkeep
 
 # Environment files with secrets
 .env

--- a/README.md
+++ b/README.md
@@ -322,8 +322,9 @@ services:
     ports:
       #
       # CloudCLI web UI — this is the only port you need.
+      # Override the host-side port from `.env` if 3001 is already in use.
       #
-      - "3001:3001"
+      - "${HOLYCLAUDE_HOST_PORT:-3001}:3001"
       #
       # Dev server ports — uncomment as needed.
       # These let you access dev servers running inside the container from your host browser.
@@ -339,13 +340,15 @@ services:
       #
       # ./data/claude — Settings, credentials, API keys, Claude's memory file.
       #                  Survives container rebuilds. NEVER delete this folder.
+      #                  Override the host path from `.env` if you want it elsewhere.
       #
-      - ./data/claude:/home/claude/.claude
+      - ${HOLYCLAUDE_HOST_CLAUDE_DIR:-./data/claude}:/home/claude/.claude
       #
       # ./workspace — Your code and projects. Everything you build goes here.
       #               Accessible from your host machine.
+      #               Override the host path from `.env` if you want a different root.
       #
-      - ./workspace:/workspace
+      - ${HOLYCLAUDE_HOST_WORKSPACE_DIR:-./workspace}:/workspace
     environment:
       #
       # TIMEZONE
@@ -402,6 +405,16 @@ Then:
 ```bash
 docker compose up -d
 ```
+
+If you want to change the host-side port or bind-mount paths without editing compose, copy `.env.example` to `.env` and set:
+
+```dotenv
+HOLYCLAUDE_HOST_PORT=3003
+HOLYCLAUDE_HOST_CLAUDE_DIR=./data/claude
+HOLYCLAUDE_HOST_WORKSPACE_DIR=./workspace
+```
+
+These values are read by Docker Compose on the host. They are not container environment variables.
 
 ### What each section controls:
 

--- a/docker-compose.full.yaml
+++ b/docker-compose.full.yaml
@@ -18,7 +18,7 @@ services:
     security_opt:
       - seccomp=unconfined
     ports:
-      - "3001:3001"           # CloudCLI web UI
+      - "${HOLYCLAUDE_HOST_PORT:-3001}:3001"   # CloudCLI web UI
       # --- Uncomment ports as needed ---
       # - "3000:3000"         # Dev server (Next.js, Express)
       # - "4321:4321"         # Astro dev
@@ -26,8 +26,8 @@ services:
       # - "8787:8787"         # Wrangler dev
       # - "9229:9229"         # Node.js debugger
     volumes:
-      - ./data/claude:/home/claude/.claude
-      - ./workspace:/workspace
+      - ${HOLYCLAUDE_HOST_CLAUDE_DIR:-./data/claude}:/home/claude/.claude
+      - ${HOLYCLAUDE_HOST_WORKSPACE_DIR:-./workspace}:/workspace
     environment:
       # --- Required ---
       - TZ=UTC                                    # Your timezone (e.g., America/New_York)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,11 +49,13 @@ Runs every time the container starts. Responsibilities:
 
 1. **UID/GID remapping** — Adjusts the `claude` user's UID/GID to match `PUID`/`PGID` environment variables. This prevents permission mismatches between container and host files.
 
-2. **File pre-creation** — Ensures `~/.claude.json` exists as a file (not a directory). Docker creates bind-mount targets as directories if they don't exist, which breaks Claude Code.
+2. **Workspace ownership fix** — Repairs the top-level `/workspace` bind mount if Docker auto-created it as `root:root` on first start.
 
-3. **Bootstrap trigger** — Checks for sentinel file `.holyclaude-bootstrapped`. If absent, runs `bootstrap.sh`.
+3. **File pre-creation** — Ensures `~/.claude.json` exists as a file (not a directory). Docker creates bind-mount targets as directories if they don't exist, which breaks Claude Code.
 
-4. **Handoff** — `exec /init` replaces the entrypoint process with s6-overlay, which becomes PID 1.
+4. **Bootstrap trigger** — Checks for sentinel file `.holyclaude-bootstrapped`. If absent, runs `bootstrap.sh`.
+
+5. **Handoff** — `exec /init` replaces the entrypoint process with s6-overlay, which becomes PID 1.
 
 ### Bootstrap (`bootstrap.sh`)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,16 @@ HolyClaude ships with two compose files:
 
 ## Environment Variables
 
+Docker Compose also supports a local `.env` file for variable interpolation. HolyClaude uses that in `docker-compose.full.yaml` for host-side port and bind-mount paths. These values are read by Compose on the host and are not passed into the container unless you also list them under `environment:`.
+
+### Compose-Level Host Mappings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HOLYCLAUDE_HOST_PORT` | `3001` | Host port mapped to container port `3001` |
+| `HOLYCLAUDE_HOST_CLAUDE_DIR` | `./data/claude` | Host path bind-mounted to `/home/claude/.claude` |
+| `HOLYCLAUDE_HOST_WORKSPACE_DIR` | `./workspace` | Host path bind-mounted to `/workspace` |
+
 ### Core
 
 | Variable | Default | Description |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,7 +57,10 @@ Note: Polling uses more CPU than inotify. Only enable when needed.
 
 **Symptom:** Can't write files, `git` operations fail, npm install fails.
 
-**Cause:** Container UID/GID doesn't match host file ownership.
+**Cause:** Usually one of these:
+
+- `PUID`/`PGID` doesn't match your host user
+- Docker auto-created `./workspace` as `root:root` on first start because the directory did not exist yet
 
 **Fix:** Set `PUID` and `PGID` to match your host user:
 ```bash
@@ -72,6 +75,8 @@ environment:
   - PUID=1000
   - PGID=1000
 ```
+
+HolyClaude also auto-fixes the top-level `/workspace` ownership on boot if Docker created it as root. If you still have permission errors after startup, the remaining mismatch is in your host files, not the container's workspace mount point.
 
 ---
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -8,6 +8,7 @@ set -e
 
 CLAUDE_USER="claude"
 CLAUDE_HOME="/home/claude"
+WORKSPACE_DIR="/workspace"
 
 # ---------- UID/GID remapping ----------
 PUID="${PUID:-1000}"
@@ -29,6 +30,19 @@ fi
 # ---------- Fix home directory ownership ----------
 chown "$PUID:$PGID" "$CLAUDE_HOME"
 chown "$PUID:$PGID" "$CLAUDE_HOME/.claude" 2>/dev/null || true
+
+# ---------- Ensure /workspace is writable ----------
+# Docker creates missing bind-mount directories as root on the host.
+# Fix the top-level workspace ownership here so the mapped claude user can write.
+mkdir -p "$WORKSPACE_DIR"
+if ! runuser -u "$CLAUDE_USER" -- test -w "$WORKSPACE_DIR"; then
+    echo "[entrypoint] /workspace is not writable for $CLAUDE_USER — attempting ownership fix"
+    chown "$PUID:$PGID" "$WORKSPACE_DIR" 2>/dev/null || true
+fi
+
+if ! runuser -u "$CLAUDE_USER" -- test -w "$WORKSPACE_DIR"; then
+    echo "[entrypoint] WARNING: /workspace is still not writable; fix host ownership or PUID/PGID"
+fi
 
 # ---------- Pre-create ~/.claude.json as a FILE ----------
 # If this does not exist before Docker mounts, Docker creates it as a DIRECTORY

--- a/workspace/.gitkeep
+++ b/workspace/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this directory in git so Docker does not create it as root on first run.


### PR DESCRIPTION
## Summary

This PR fixes first-run workspace permission issues and makes the host-side mappings in `docker-compose.full.yaml` configurable through `.env`.

## Changes

- add a startup self-heal in `scripts/entrypoint.sh` to repair the top-level `/workspace` bind mount when Docker auto-creates it as `root:root`
- keep `workspace/` in git with `.gitkeep` so fresh clones do not depend on Docker creating the directory
- add `.env.example`
- make the host-side CloudCLI port and bind-mount paths configurable in `docker-compose.full.yaml`
  - `HOLYCLAUDE_HOST_PORT`
  - `HOLYCLAUDE_HOST_CLAUDE_DIR`
  - `HOLYCLAUDE_HOST_WORKSPACE_DIR`
- update README and configuration/troubleshooting/architecture docs to match the new behavior

## Validation

- verified `docker compose config` resolves the default values correctly
- verified `docker compose config` resolves override values correctly when host-side variables are set
- rebuilt the local image with the updated entrypoint
- forced the host `workspace/` directory back to `root:root`, recreated the container, and confirmed startup repairs ownership and restores write access for the `claude` user
