### PR TITLE
Auto-update Claude Code on container boot

### DIFF
--- a/docker-compose.full.yaml
+++ b/docker-compose.full.yaml
@@ -38,6 +38,9 @@ services:
       # --- Performance ---
       - NODE_OPTIONS=--max-old-space-size=4096     # Node.js memory limit (MB)
 
+      # --- Claude Code auto-update ---
+      - CLAUDE_AUTO_UPDATE=true                    # Run `claude update` on every container start (set false to pin)
+
       # --- User mapping (match your host UID/GID) ---
       - PUID=1000
       - PGID=1000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,4 +23,5 @@ services:
       - ./data/claude:/home/claude/.claude
       - ./workspace:/workspace
     environment:
-      - TZ=UTC          # Change to your timezone
+      - TZ=UTC                  # Change to your timezone
+      - CLAUDE_AUTO_UPDATE=true # Run `claude update` on every container start

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -98,6 +98,19 @@ if [ ! -f "$SENTINEL" ]; then
     fi
 fi
 
+# ---------- Claude Code auto-update (every boot, best-effort) ----------
+# The image bakes in whatever Claude Code was current at build time. To pick up
+# new releases without rebuilding the image, run `claude update` on each boot.
+# Set CLAUDE_AUTO_UPDATE=false to skip (e.g. air-gapped or pinned environments).
+if [ "${CLAUDE_AUTO_UPDATE:-true}" = "true" ]; then
+    echo "[entrypoint] Checking for Claude Code updates..."
+    if runuser -u "$CLAUDE_USER" -- bash -lc 'claude update' 2>&1 | sed 's/^/[claude-update] /'; then
+        :
+    else
+        echo "[entrypoint] WARNING: claude update failed — continuing with installed version"
+    fi
+fi
+
 # ---------- Background: persist ~/.claude.json every 60s ----------
 (while true; do
     sleep 60


### PR DESCRIPTION
## Summary

- The image bakes Claude Code in at build time (Dockerfile L105), so users on the published `coderluii/holyclaude:latest` are pinned to whatever Claude Code version was current at build time.
- This PR adds a best-effort `claude update` step to `entrypoint.sh` that runs as the `claude` user on every boot, so containers pick up new Claude Code releases without an image rebuild.
- Behavior is gated by a new `CLAUDE_AUTO_UPDATE` env var (default `true`). Set it to `false` for air-gapped or version-pinned environments.

Failures are logged via `[claude-update]` prefix and never block startup, so a transient network issue or upstream outage won't break boot.

## Files touched

- `scripts/entrypoint.sh` — new auto-update block, runs after first-boot bootstrap and before the `~/.claude.json` persistence loop
- `docker-compose.yaml` — documents the new env var in the quick-start file
- `docker-compose.full.yaml` — documents the new env var alongside the other performance options

## Test plan

- [ ] `docker compose up -d` on a fresh build — observe `[entrypoint] Checking for Claude Code updates...` followed by `[claude-update]`-prefixed output, and confirm `docker exec -u claude holyclaude claude --version` reports the latest release
- [ ] `CLAUDE_AUTO_UPDATE=false docker compose up -d` — confirm the update step is skipped
- [ ] Boot with no network — confirm the warning is logged and s6-overlay still starts cleanly