### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1444,11 +1444,11 @@ MIT — see [LICENSE](LICENSE). Use it however you want.
 
 <!-- Star History -->
 <div align="center">
-<a href="https://star-history.com/#CoderLuii/HolyClaude&Date">
+<a href="https://star-history.dera.page/#CoderLuii/HolyClaude&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
   </picture>
 </a>
 </div>

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -1215,11 +1215,11 @@ MIT — siehe [LICENSE](../../LICENSE). Verwende es, wie du möchtest.
 
 <!-- Star History -->
 <div align="center">
-<a href="https://star-history.com/#CoderLuii/HolyClaude&Date">
+<a href="https://star-history.dera.page/#CoderLuii/HolyClaude&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
   </picture>
 </a>
 </div>

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -1214,11 +1214,11 @@ MIT — consulta [LICENSE](../../LICENSE). Usalo como quieras.
 
 <!-- Star History -->
 <div align="center">
-<a href="https://star-history.com/#CoderLuii/HolyClaude&Date">
+<a href="https://star-history.dera.page/#CoderLuii/HolyClaude&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
   </picture>
 </a>
 </div>

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -1215,11 +1215,11 @@ MIT — voir [LICENSE](../../LICENSE). Utilisez-le comme vous voulez.
 
 <!-- Star History -->
 <div align="center">
-<a href="https://star-history.com/#CoderLuii/HolyClaude&Date">
+<a href="https://star-history.dera.page/#CoderLuii/HolyClaude&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
   </picture>
 </a>
 </div>

--- a/docs/translations/README.hi.md
+++ b/docs/translations/README.hi.md
@@ -1215,11 +1215,11 @@ MIT — [LICENSE](../../LICENSE) देखें। इसे जैसे च�
 
 <!-- Star History -->
 <div align="center">
-<a href="https://star-history.com/#CoderLuii/HolyClaude&Date">
+<a href="https://star-history.dera.page/#CoderLuii/HolyClaude&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
   </picture>
 </a>
 </div>

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -1215,11 +1215,11 @@ MIT — vedi [LICENSE](../../LICENSE). Usalo come vuoi.
 
 <!-- Star History -->
 <div align="center">
-<a href="https://star-history.com/#CoderLuii/HolyClaude&Date">
+<a href="https://star-history.dera.page/#CoderLuii/HolyClaude&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
   </picture>
 </a>
 </div>

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -1215,11 +1215,11 @@ MIT — [LICENSE](../../LICENSE) を参照。自由に使ってください。
 
 <!-- Star History -->
 <div align="center">
-<a href="https://star-history.com/#CoderLuii/HolyClaude&Date">
+<a href="https://star-history.dera.page/#CoderLuii/HolyClaude&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
   </picture>
 </a>
 </div>

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -1215,11 +1215,11 @@ MIT — [LICENSE](../../LICENSE) 참조. 원하는 대로 사용하세요.
 
 <!-- Star History -->
 <div align="center">
-<a href="https://star-history.com/#CoderLuii/HolyClaude&Date">
+<a href="https://star-history.dera.page/#CoderLuii/HolyClaude&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
   </picture>
 </a>
 </div>

--- a/docs/translations/README.pt.md
+++ b/docs/translations/README.pt.md
@@ -1215,11 +1215,11 @@ MIT — veja [LICENSE](../../LICENSE). Use como quiser.
 
 <!-- Star History -->
 <div align="center">
-<a href="https://star-history.com/#CoderLuii/HolyClaude&Date">
+<a href="https://star-history.dera.page/#CoderLuii/HolyClaude&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
   </picture>
 </a>
 </div>

--- a/docs/translations/README.zh.md
+++ b/docs/translations/README.zh.md
@@ -1215,11 +1215,11 @@ MIT — 查看 [LICENSE](../../LICENSE)。随意使用。
 
 <!-- Star History -->
 <div align="center">
-<a href="https://star-history.com/#CoderLuii/HolyClaude&Date">
+<a href="https://star-history.dera.page/#CoderLuii/HolyClaude&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CoderLuii/HolyClaude&type=Date" width="600" />
   </picture>
 </a>
 </div>


### PR DESCRIPTION
The star history chart shown in the README is currently broken and no longer renders for visitors. Update the chart links and image endpoints across the main README and all translations to point to a working data source so the chart displays correctly again.