### PR TITLE
Update Pi Coding Agent to 0.84.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -529,7 +529,7 @@ RUN if [ "$VARIANT" = "full" ]; then \
 
 # ---------- Pi Coding Agent (full only) ----------
 RUN if [ "$VARIANT" = "full" ]; then \
-    npm i -g --ignore-scripts @earendil-works/pi-coding-agent@0.82.1; \
+    npm i -g --ignore-scripts @earendil-works/pi-coding-agent@0.84.3; \
     fi
 
 # Replace compatible vulnerable transitive packages without changing tool majors.

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -174,7 +174,7 @@ create `.desloppify/`, or modify project files unless a user runs Desloppify.
 - License: MIT
 - Source: https://github.com/earendil-works/pi
 - npm: https://www.npmjs.com/package/@earendil-works/pi-coding-agent
-- Version: 0.82.1, installed in the full image only
+- Version: 0.84.3, installed in the full image only
 
 ## Downstream security backports
 

--- a/contracts/product-facts.json
+++ b/contracts/product-facts.json
@@ -105,7 +105,7 @@
       "id": "pi-coding-agent",
       "name": "Pi Coding Agent",
       "command": "pi",
-      "version": "0.82.1",
+      "version": "0.84.3",
       "variants": [
         "full"
       ]

--- a/scripts/patch-global-node-security-dependencies.mjs
+++ b/scripts/patch-global-node-security-dependencies.mjs
@@ -76,7 +76,7 @@ const FULL_DEPENDENCIES = [
   [
     'usr/local/lib/node_modules/@earendil-works/pi-coding-agent/package.json',
     '@earendil-works/pi-coding-agent',
-    '0.82.1',
+    '0.84.3',
     'undici',
     '8.5.0',
     '8.9.0',

--- a/tests/browser_runtime_container_checks.sh
+++ b/tests/browser_runtime_container_checks.sh
@@ -188,7 +188,7 @@ const common = {
 };
 const full = {
   '@cloudflare/next-on-pages': '1.13.16',
-  '@earendil-works/pi-coding-agent': '0.82.1',
+  '@earendil-works/pi-coding-agent': '0.84.3',
   '@lhci/cli': '0.15.1',
   '@marp-team/marp-cli': '4.5.0',
   'drizzle-kit': '0.31.10',
@@ -359,7 +359,7 @@ assert_runtime_identity() {
     require_eq "Lighthouse package version" "$(node -p "require('/usr/local/lib/node_modules/lighthouse/package.json').version")" "13.4.1"
     require_eq "Marp CLI package version" "$(node -p "require('/usr/local/lib/node_modules/@marp-team/marp-cli/package.json').version")" "4.5.0"
     require_eq "OpenCode package version" "$(node -p "require('/usr/local/lib/node_modules/opencode-ai/package.json').version")" "1.18.10"
-    require_eq "Pi package version" "$(node -p "require('/usr/local/lib/node_modules/@earendil-works/pi-coding-agent/package.json').version")" "0.82.1"
+    require_eq "Pi package version" "$(node -p "require('/usr/local/lib/node_modules/@earendil-works/pi-coding-agent/package.json').version")" "0.84.3"
     require_eq "Pi undici dependency" "$(node -p "require('/usr/local/lib/node_modules/@earendil-works/pi-coding-agent/package.json').dependencies.undici")" "8.9.0"
     require_eq "Pi undici package version" "$(node -p "require('/usr/local/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/undici/package.json').version")" "8.9.0"
     npm --prefix /usr/local/lib/node_modules/@earendil-works/pi-coding-agent ls undici --all >/dev/null

--- a/tests/patch_global_node_security_dependencies.test.mjs
+++ b/tests/patch_global_node_security_dependencies.test.mjs
@@ -79,7 +79,7 @@ const dependencies = [
   [
     'usr/local/lib/node_modules/@earendil-works/pi-coding-agent/package.json',
     '@earendil-works/pi-coding-agent',
-    '0.82.1',
+    '0.84.3',
     'undici',
     '8.5.0',
     '8.9.0',

--- a/tests/release_input_integrity.test.mjs
+++ b/tests/release_input_integrity.test.mjs
@@ -211,7 +211,7 @@ test('compatible package updates and plugin locks are exact', () => {
     '@google/gemini-cli@0.53.0',
     '@openai/codex@0.146.0',
     'opencode-ai@1.18.10',
-    '@earendil-works/pi-coding-agent@0.82.1',
+    '@earendil-works/pi-coding-agent@0.84.3',
     'pandas==3.0.5',
     'tqdm==4.70.0',
     'matplotlib==3.11.1',


### PR DESCRIPTION
Updates Pi Coding Agent from 0.82.1 to 0.84.3, the latest upstream release published on 2026-08-24. The published package retains the reviewed undici 8.9.0 dependency.\n\nTests: node --test tests/immutable_inputs_policy.test.mjs tests/product_facts.test.mjs tests/release_input_integrity.test.mjs