### PR TITLE
Update Codex to 0.151.0 and use its current hooks feature flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -465,7 +465,7 @@ RUN curl --disable --retry 8 --retry-all-errors --retry-max-time 300 --remove-on
     rm -f "/tmp/setuptools-${SETUPTOOLS_VERSION}-py3-none-any.whl"
 
 # ---------- AI CLI providers ----------
-RUN npm i -g @google/gemini-cli@0.53.0 @openai/codex@0.146.0 task-master-ai@0.43.1
+RUN npm i -g @google/gemini-cli@0.53.0 @openai/codex@0.151.0 task-master-ai@0.43.1
 USER claude
 RUN CURSOR_ASSET_ARCH=$(case "$TARGETARCH" in amd64) echo "x64";; arm64) echo "arm64";; *) echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1;; esac) && \
     CURSOR_ARCHIVE_SHA256=$(case "$TARGETARCH" in amd64) echo "$CURSOR_ARCHIVE_SHA256_AMD64";; arm64) echo "$CURSOR_ARCHIVE_SHA256_ARM64";; *) echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1;; esac) && \

--- a/contracts/product-facts.json
+++ b/contracts/product-facts.json
@@ -57,7 +57,7 @@
       "id": "openai-codex",
       "name": "OpenAI Codex",
       "command": "codex",
-      "version": "0.146.0",
+      "version": "0.151.0",
       "variants": [
         "full",
         "slim"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -80,11 +80,11 @@ approval_policy = "$CODEX_CLI_APPROVAL_POLICY"
 sandbox_mode = "$CODEX_CLI_SANDBOX_MODE"
 
 [features]
-codex_hooks = true
+hooks = true
 TOML
     echo "[bootstrap] Created Codex CLI config ($CODEX_CLI_CONFIG_LABEL, hooks enabled)"
 elif ! grep -q '^\[features\]' "$CLAUDE_HOME/.codex/config.toml"; then
-    printf '\n[features]\ncodex_hooks = true\n' >> "$CLAUDE_HOME/.codex/config.toml"
+    printf '\n[features]\nhooks = true\n' >> "$CLAUDE_HOME/.codex/config.toml"
     echo "[bootstrap] Added [features] section to existing Codex config"
 fi
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -352,6 +352,25 @@ if [ ! -e "$CLAUDE_HOME/.codex" ]; then
     chown_if_root -h "$PUID:$PGID" "$CLAUDE_HOME/.codex"
 fi
 
+# ---------- Codex CLI feature flag migration (every boot) ----------
+# Codex renamed the hooks feature flag to [features].hooks. The old
+# [features].codex_hooks key still works but warns on every session start, and
+# the config is persisted under ~/.claude, so images shipped before the rename
+# leave the deprecated key behind. Rewrite in place rather than with sed -i so
+# a root startup does not take ownership of a file the claude user must write.
+CODEX_CONFIG="$CLAUDE_HOME/.codex/config.toml"
+if [ -f "$CODEX_CONFIG" ] && grep -q '^[[:space:]]*codex_hooks[[:space:]]*=' "$CODEX_CONFIG"; then
+    if grep -q '^[[:space:]]*hooks[[:space:]]*=' "$CODEX_CONFIG"; then
+        codex_config_migrated="$(sed '/^[[:space:]]*codex_hooks[[:space:]]*=/d' "$CODEX_CONFIG")"
+        codex_config_action="Dropped deprecated [features].codex_hooks (hooks already set)"
+    else
+        codex_config_migrated="$(sed 's/^\([[:space:]]*\)codex_hooks\([[:space:]]*=\)/\1hooks\2/' "$CODEX_CONFIG")"
+        codex_config_action="Renamed deprecated [features].codex_hooks to [features].hooks"
+    fi
+    printf '%s\n' "$codex_config_migrated" > "$CODEX_CONFIG"
+    echo "[entrypoint] $codex_config_action in Codex CLI config"
+fi
+
 # ---------- Gemini CLI config symlink (every boot) ----------
 mkdir -p "$CLAUDE_HOME/.claude/.gemini"
 chown_if_root "$PUID:$PGID" "$CLAUDE_HOME/.claude/.gemini"

--- a/tests/browser_runtime_container_checks.sh
+++ b/tests/browser_runtime_container_checks.sh
@@ -170,7 +170,7 @@ const variant = process.argv[3];
 const common = {
   '@cloudcli-ai/cloudcli': '1.36.3',
   '@google/gemini-cli': '0.53.0',
-  '@openai/codex': '0.146.0',
+  '@openai/codex': '0.151.0',
   concurrently: '10.0.4',
   'dotenv-cli': '11.0.0',
   esbuild: '0.28.2',
@@ -292,7 +292,7 @@ assert_runtime_identity() {
   require_eq "pnpm version" "$(pnpm --version)" "11.21.0"
   require_eq "Vite package version" "$(node -p "require('/usr/local/lib/node_modules/vite/package.json').version")" "8.2.1"
   require_eq "Prettier package version" "$(node -p "require('/usr/local/lib/node_modules/prettier/package.json').version")" "3.9.6"
-  require_eq "Codex package version" "$(node -p "require('/usr/local/lib/node_modules/@openai/codex/package.json').version")" "0.146.0"
+  require_eq "Codex package version" "$(node -p "require('/usr/local/lib/node_modules/@openai/codex/package.json').version")" "0.151.0"
   require_eq "Gemini package version" "$(node -p "require('/usr/local/lib/node_modules/@google/gemini-cli/package.json').version")" "0.53.0"
   require_eq "tree-sitter language pack" "$(python3 -c 'import importlib.metadata; print(importlib.metadata.version("tree-sitter-language-pack"))')" "1.6.2"
   require_eq "tqdm package version" "$(python3 -c 'import importlib.metadata; print(importlib.metadata.version("tqdm"))')" "4.70.0"

--- a/tests/codex_feature_flag.test.mjs
+++ b/tests/codex_feature_flag.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+
+const entrypoint = readFileSync('scripts/entrypoint.sh', 'utf8');
+const bootstrap = readFileSync('scripts/bootstrap.sh', 'utf8');
+
+const MIGRATION_HEADER = '# ---------- Codex CLI feature flag migration (every boot) ----------';
+
+function migrationBlock() {
+  const start = entrypoint.indexOf(MIGRATION_HEADER);
+  assert.notEqual(start, -1, 'entrypoint should carry the Codex feature flag migration section');
+  const end = entrypoint.indexOf('\n# ---------- ', start + MIGRATION_HEADER.length);
+  assert.notEqual(end, -1, 'migration section should be followed by another entrypoint section');
+  return entrypoint.slice(start, end);
+}
+
+function runMigration(config) {
+  const root = mkdtempSync(join(tmpdir(), 'codex-features-'));
+  try {
+    mkdirSync(join(root, '.codex'), { recursive: true });
+    const configPath = join(root, '.codex/config.toml');
+    writeFileSync(configPath, config);
+    const result = spawnSync('bash', ['-c', `set -e\nCLAUDE_HOME="$1"\n${migrationBlock()}`, 'bash', root], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return { config: readFileSync(configPath, 'utf8'), stdout: result.stdout };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('bootstrap seeds the current Codex hooks feature flag', () => {
+  assert.match(bootstrap, /^\[features\]\nhooks = true$/m);
+  assert.match(bootstrap, /printf '\\n\[features\]\\nhooks = true\\n'/);
+  assert.doesNotMatch(bootstrap, /codex_hooks/);
+});
+
+test('entrypoint renames the deprecated codex_hooks key on an existing config', () => {
+  const { config, stdout } = runMigration(
+    'approval_policy = "on-request"\nsandbox_mode = "workspace-write"\n\n[features]\ncodex_hooks = true\n',
+  );
+
+  assert.equal(
+    config,
+    'approval_policy = "on-request"\nsandbox_mode = "workspace-write"\n\n[features]\nhooks = true\n',
+  );
+  assert.match(stdout, /Renamed deprecated \[features\]\.codex_hooks/);
+});
+
+test('entrypoint drops codex_hooks instead of duplicating an existing hooks key', () => {
+  const { config, stdout } = runMigration('[features]\nhooks = false\ncodex_hooks = true\n');
+
+  assert.equal(config, '[features]\nhooks = false\n');
+  assert.match(stdout, /Dropped deprecated \[features\]\.codex_hooks/);
+});
+
+test('entrypoint leaves an already migrated config untouched', () => {
+  const original = 'approval_policy = "never"\n\n[features]\nhooks = true\n\n[hooks.state]\n';
+  const { config, stdout } = runMigration(original);
+
+  assert.equal(config, original);
+  assert.equal(stdout, '');
+});
+
+test('migration runs on every boot, not only behind the first-boot sentinel', () => {
+  const migration = entrypoint.indexOf(MIGRATION_HEADER);
+  const bootstrapGate = entrypoint.indexOf('# ---------- First-boot bootstrap ----------');
+
+  assert.notEqual(bootstrapGate, -1);
+  assert.ok(migration < bootstrapGate);
+  const statements = migrationBlock().replace(/^#.*$/gm, '');
+  assert.doesNotMatch(statements, /sed -i/, 'in-place sed would reassign ownership under a root startup');
+});

--- a/tests/release_input_integrity.test.mjs
+++ b/tests/release_input_integrity.test.mjs
@@ -209,7 +209,7 @@ test('compatible package updates and plugin locks are exact', () => {
     'lighthouse@13.4.1',
     '@marp-team/marp-cli@4.5.0',
     '@google/gemini-cli@0.53.0',
-    '@openai/codex@0.146.0',
+    '@openai/codex@0.151.0',
     'opencode-ai@1.18.10',
     '@earendil-works/pi-coding-agent@0.82.1',
     'pandas==3.0.5',


### PR DESCRIPTION
Updates Codex to 0.151.0 (npm `latest`) across the Dockerfile pin, product facts, and the runtime identity assertions.

Also fixes the deprecation warning Codex prints on every session start:

```
`[features].codex_hooks` is deprecated. Use `[features].hooks` instead
```

`codex features list` reports `hooks` as the stable name, with `codex_hooks` kept only as a deprecated alias. Bootstrap now seeds `hooks = true`, and because `~/.codex` is symlinked into the bind-mounted `~/.claude`, the entrypoint also migrates an existing config on every boot — first-boot bootstrap alone never reaches installs created before the rename. The rewrite truncates in place rather than using `sed -i`, so a root startup does not take ownership of a file the `claude` user has to write, and it drops rather than renames `codex_hooks` when `hooks` is already set, to avoid producing a duplicate TOML key.

Tests: `node --test tests/*.test.mjs` — 227/230, the 3 failures being the pre-existing environment-bound ones (two CloudCLI snapshot-retry tests and the cryptography manifest relocation test) that also fail on unmodified `master` here. New coverage in `tests/codex_feature_flag.test.mjs` executes the migration block against real config files. `bash -n scripts/*.sh tests/*.sh`, `verify-product-facts.mjs`, and `verify-immutable-inputs.mjs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzRKYNfCu8d9DV1uyDQjsi